### PR TITLE
feat(graphics): expose original image dimensions for aspect ratio preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Original Image Dimensions**: All graphics protocols (Sixel, iTerm2, Kitty) now expose `original_width` and `original_height` on `TerminalGraphic` and Python `Graphic` objects
+  - These preserve the original decoded pixel dimensions even when `width`/`height` change during animation
+  - Enables frontends to calculate correct aspect ratios when scaling images to fit terminal cells
+  - Python `Graphic.__repr__()` now includes `original_size=WxH`
 - **Kitty Graphics Compression (o=z)**: Support for zlib-compressed image data in the Kitty graphics protocol
   - Parses the `o=z` transmission parameter to detect zlib-compressed payloads
   - Automatically decompresses data before pixel decoding (transparent to consumers)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ A comprehensive terminal emulator library written in Rust with Python bindings f
 
 ## What's New (Unreleased)
 
+### Original Image Dimensions for Aspect Ratio Preservation
+
+All graphics protocols (Sixel, iTerm2, Kitty) now expose `original_width` and `original_height` on `Graphic` objects. These fields preserve the original decoded pixel dimensions even when `width`/`height` change during animation, enabling frontends to calculate correct aspect ratios when scaling images to fit terminal cells.
+
 ### Kitty Graphics Compression Support
 
 The Kitty graphics protocol now supports zlib-compressed image payloads (`o=z` parameter). Compressed data is automatically decompressed before pixel decoding, reducing data sent over the PTY. A new `was_compressed` flag on the `Graphic` class allows frontends to track compression usage for diagnostics.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -809,8 +809,10 @@ Protocol-agnostic graphic representation (Sixel, iTerm2, or Kitty).
 - `id: int`: Unique placement ID
 - `protocol: str`: Graphics protocol used (`"sixel"`, `"iterm"`, or `"kitty"`)
 - `position: tuple[int, int]`: Position in terminal `(col, row)`
-- `width: int`: Width in pixels
-- `height: int`: Height in pixels
+- `width: int`: Width in pixels (may change during animation)
+- `height: int`: Height in pixels (may change during animation)
+- `original_width: int`: Original width in pixels as decoded from source image (immutable, for aspect ratio preservation)
+- `original_height: int`: Original height in pixels as decoded from source image (immutable, for aspect ratio preservation)
 - `scroll_offset_rows: int`: Rows scrolled off visible area (for partial rendering)
 - `cell_dimensions: tuple[int, int] | None`: Cell dimensions `(cell_width, cell_height)` for rendering
 - `was_compressed: bool`: Whether the original data was compressed (e.g., Kitty `o=z` zlib). Useful for diagnostics/logging.

--- a/src/python_bindings/types.rs
+++ b/src/python_bindings/types.rs
@@ -283,6 +283,10 @@ pub struct PyGraphic {
     #[pyo3(get)]
     pub height: usize,
     #[pyo3(get)]
+    pub original_width: usize,
+    #[pyo3(get)]
+    pub original_height: usize,
+    #[pyo3(get)]
     pub scroll_offset_rows: usize,
     #[pyo3(get)]
     pub cell_dimensions: Option<(u32, u32)>,
@@ -359,8 +363,15 @@ impl PyGraphic {
 
     fn __repr__(&self) -> PyResult<String> {
         Ok(format!(
-            "Graphic(id={}, protocol='{}', position=({},{}), size={}x{})",
-            self.id, self.protocol, self.position.0, self.position.1, self.width, self.height
+            "Graphic(id={}, protocol='{}', position=({},{}), size={}x{}, original_size={}x{})",
+            self.id,
+            self.protocol,
+            self.position.0,
+            self.position.1,
+            self.width,
+            self.height,
+            self.original_width,
+            self.original_height
         ))
     }
 }
@@ -373,6 +384,8 @@ impl From<&crate::sixel::SixelGraphic> for PyGraphic {
             position: graphic.position,
             width: graphic.width,
             height: graphic.height,
+            original_width: graphic.width,
+            original_height: graphic.height,
             scroll_offset_rows: graphic.scroll_offset_rows,
             cell_dimensions: graphic.cell_dimensions,
             was_compressed: false,
@@ -389,6 +402,8 @@ impl From<&crate::graphics::TerminalGraphic> for PyGraphic {
             position: graphic.position,
             width: graphic.width,
             height: graphic.height,
+            original_width: graphic.original_width,
+            original_height: graphic.original_height,
             scroll_offset_rows: graphic.scroll_offset_rows,
             cell_dimensions: graphic.cell_dimensions,
             was_compressed: graphic.was_compressed,
@@ -3565,6 +3580,8 @@ mod tests {
             position: (0, 0),
             width: 2,
             height: 2,
+            original_width: 2,
+            original_height: 2,
             scroll_offset_rows: 0,
             cell_dimensions: None,
             was_compressed: false,
@@ -3585,6 +3602,8 @@ mod tests {
             position: (0, 0),
             width: 2,
             height: 2,
+            original_width: 2,
+            original_height: 2,
             scroll_offset_rows: 0,
             cell_dimensions: None,
             was_compressed: false,
@@ -3604,6 +3623,8 @@ mod tests {
             position: (5, 10),
             width: 3,
             height: 3,
+            original_width: 3,
+            original_height: 3,
             scroll_offset_rows: 0,
             cell_dimensions: None,
             was_compressed: false,
@@ -3630,6 +3651,8 @@ mod tests {
             position: (0, 0),
             width: 2,
             height: 1,
+            original_width: 2,
+            original_height: 1,
             scroll_offset_rows: 0,
             cell_dimensions: None,
             was_compressed: false,
@@ -3649,6 +3672,8 @@ mod tests {
             position: (10, 20),
             width: 100,
             height: 50,
+            original_width: 100,
+            original_height: 50,
             scroll_offset_rows: 0,
             cell_dimensions: None,
             was_compressed: false,
@@ -3670,6 +3695,8 @@ mod tests {
             position: (5, 10),
             width: 20,
             height: 30,
+            original_width: 20,
+            original_height: 30,
             scroll_offset_rows: 0,
             cell_dimensions: None,
             was_compressed: false,
@@ -3708,6 +3735,8 @@ mod tests {
             position: (0, 0),
             width: 2,
             height: 2,
+            original_width: 2,
+            original_height: 2,
             scroll_offset_rows: 0,
             cell_dimensions: None,
             was_compressed: false,
@@ -3834,6 +3863,8 @@ mod tests {
             position: (0, 0),
             width: 4,
             height: 1,
+            original_width: 4,
+            original_height: 1,
             scroll_offset_rows: 0,
             cell_dimensions: None,
             was_compressed: false,


### PR DESCRIPTION
## Summary
- Adds `original_width` and `original_height` fields to `TerminalGraphic` (Rust) and `Graphic` (Python) for all graphics protocols (Sixel, iTerm2, Kitty)
- These fields preserve the original decoded pixel dimensions even when `width`/`height` change during animation frames
- Enables frontends to calculate correct aspect ratios when scaling images to fit terminal cells

## Changes
- **`src/graphics/mod.rs`**: Added `original_width`/`original_height` fields to `TerminalGraphic`, set in both `new()` and `with_shared_pixels()` constructors; added 3 new unit tests
- **`src/python_bindings/types.rs`**: Added fields to `PyGraphic` with `#[pyo3(get)]`; updated `From<&TerminalGraphic>` and `From<&SixelGraphic>` conversions; updated `__repr__` to include `original_size=WxH`
- **`tests/test_sixel_raster_and_palette.py`**: New Python test verifying `original_width`/`original_height` are exposed on Sixel graphics
- **Docs**: Updated CHANGELOG.md, README.md, and docs/API_REFERENCE.md

## Test plan
- [x] All 1058 Rust unit tests pass
- [x] All 328 Python tests pass (40 skipped)
- [x] `make checkall` passes (fmt, clippy, pyright, ruff, tests)
- [x] Pre-commit hooks all pass

Closes #17