### PR TITLE
Preserve top-anchored scroll region lines in scrollback

### DIFF
--- a/src/grid/scroll.rs
+++ b/src/grid/scroll.rs
@@ -4,43 +4,51 @@ use crate::cell::Cell;
 use crate::grid::Grid;
 
 impl Grid {
+    fn push_rows_to_scrollback(&mut self, start_row: usize, count: usize) {
+        if self.max_scrollback == 0 || count == 0 || start_row >= self.rows {
+            return;
+        }
+
+        let available = self.rows - start_row;
+        let count = count.min(available);
+
+        self.total_lines_scrolled += count;
+        if self.scrollback_lines >= self.max_scrollback {
+            let floor = self
+                .total_lines_scrolled
+                .saturating_sub(self.max_scrollback);
+            self.evict_zones(floor);
+        }
+
+        for i in 0..count {
+            let row = start_row + i;
+            let src_start = row * self.cols;
+            let src_end = src_start + self.cols;
+            let is_wrapped = self.wrapped.get(row).copied().unwrap_or(false);
+
+            if self.scrollback_lines < self.max_scrollback {
+                self.scrollback_cells
+                    .extend_from_slice(&self.cells[src_start..src_end]);
+                self.scrollback_wrapped.push(is_wrapped);
+                self.scrollback_lines += 1;
+            } else {
+                let write_idx = self.scrollback_start;
+                let dst_start = write_idx * self.cols;
+                let dst_end = dst_start + self.cols;
+
+                self.scrollback_cells[dst_start..dst_end]
+                    .clone_from_slice(&self.cells[src_start..src_end]);
+                self.scrollback_wrapped[write_idx] = is_wrapped;
+                self.scrollback_start = (self.scrollback_start + 1) % self.max_scrollback;
+            }
+        }
+    }
+
     /// Scroll up by n lines
     pub fn scroll_up(&mut self, n: usize) {
         let n = n.min(self.rows);
 
-        if self.max_scrollback > 0 {
-            self.total_lines_scrolled += n;
-            if self.scrollback_lines >= self.max_scrollback {
-                let floor = self
-                    .total_lines_scrolled
-                    .saturating_sub(self.max_scrollback);
-                self.evict_zones(floor);
-            }
-        }
-
-        if self.max_scrollback > 0 {
-            for i in 0..n {
-                let src_start = i * self.cols;
-                let src_end = src_start + self.cols;
-                let is_wrapped = self.wrapped.get(i).copied().unwrap_or(false);
-
-                if self.scrollback_lines < self.max_scrollback {
-                    self.scrollback_cells
-                        .extend_from_slice(&self.cells[src_start..src_end]);
-                    self.scrollback_wrapped.push(is_wrapped);
-                    self.scrollback_lines += 1;
-                } else {
-                    let write_idx = self.scrollback_start;
-                    let dst_start = write_idx * self.cols;
-                    let dst_end = dst_start + self.cols;
-
-                    self.scrollback_cells[dst_start..dst_end]
-                        .clone_from_slice(&self.cells[src_start..src_end]);
-                    self.scrollback_wrapped[write_idx] = is_wrapped;
-                    self.scrollback_start = (self.scrollback_start + 1) % self.max_scrollback;
-                }
-            }
-        }
+        self.push_rows_to_scrollback(0, n);
 
         for i in n..self.rows {
             let src_start = i * self.cols;
@@ -102,6 +110,10 @@ impl Grid {
         if top == 0 && effective_bottom == self.rows - 1 && self.max_scrollback > 0 {
             self.scroll_up(n);
             return true;
+        }
+
+        if top == 0 {
+            self.push_rows_to_scrollback(0, n);
         }
 
         if n >= region_size {

--- a/src/grid/tests.rs
+++ b/src/grid/tests.rs
@@ -68,6 +68,26 @@ fn test_scroll_region_up() {
 }
 
 #[test]
+fn test_scroll_region_up_top_anchored_pushes_scrollback() {
+    let mut grid = Grid::new(5, 6, 10);
+    for row in 0..6 {
+        grid.set(0, row, Cell::new((b'A' + row as u8) as char));
+    }
+
+    assert!(grid.scroll_region_up(1, 0, 3));
+
+    assert_eq!(grid.scrollback_len(), 1);
+    let line0 = grid.scrollback_line(0).unwrap();
+    assert_eq!(line0[0].c, 'A');
+    assert_eq!(grid.get(0, 0).unwrap().c, 'B');
+    assert_eq!(grid.get(0, 1).unwrap().c, 'C');
+    assert_eq!(grid.get(0, 2).unwrap().c, 'D');
+    assert_eq!(grid.get(0, 3).unwrap().c, ' ');
+    assert_eq!(grid.get(0, 4).unwrap().c, 'E');
+    assert_eq!(grid.get(0, 5).unwrap().c, 'F');
+}
+
+#[test]
 fn test_scroll_region_down() {
     let mut grid = Grid::new(80, 10, 1000);
     for i in 0..10 {


### PR DESCRIPTION
## Summary
- preserve primary-screen scrollback when a scroll region is top-anchored but not full-height
- refactor scrollback insertion into a shared helper used by both full-screen and region scrolling
- add a regression test covering `scroll_region_up()` with `top == 0`

## Problem
Codex CLI uses a top-anchored primary-screen scroll region instead of the alternate screen. `par-term-emu-core-rust` only pushed lines into scrollback when the scroll region covered the full screen, so rows scrolled off the top of a top-anchored partial region were lost instead of entering native terminal scrollback.

That caused par-term-emu-core-rust to diverge from iTerm2 behavior: live Codex content rendered correctly, but upward scrolling missed conversation history.

## Fix
When `scroll_region_up()` scrolls a region whose top margin is row 1 (`top == 0` in 0-based indexing), push the evicted top rows into primary-screen scrollback before shifting the region contents.

This keeps the previous behavior for:
- full-screen scrolling
- non-top-anchored subregions
- alternate screen behavior

## Testing
- added `test_scroll_region_up_top_anchored_pushes_scrollback`
- verified locally with:
  - `cargo +1.88.0-aarch64-apple-darwin test --no-default-features --features rust-only test_scroll_region_up_top_anchored_pushes_scrollback -- --nocapture`
