### PR TITLE
fix: implement BCE (Background Color Erase) for all erase operations

### DIFF
--- a/src/grid/erase.rs
+++ b/src/grid/erase.rs
@@ -1,75 +1,101 @@
 //! Erase and clear operations for the terminal grid
+//!
+//! BCE (Background Color Erase): VT-compatible erase operations fill erased
+//! cells with the current SGR background color rather than always defaulting
+//! to black. All erase methods accept a `bg` parameter for this purpose.
 
-use crate::cell::Cell;
+use crate::color::{Color, NamedColor};
 use crate::grid::Grid;
 
+/// Default background used by non-erase callers (scroll, edit)
+pub(crate) const DEFAULT_BG: Color = Color::Named(NamedColor::Black);
+
 impl Grid {
-    /// Clear the entire grid
-    pub fn clear(&mut self) {
-        self.cells.fill(Cell::default());
+    /// Clear the entire grid, filling cells with the given background color (BCE)
+    pub fn clear_with_bg(&mut self, bg: Color) {
+        for cell in &mut self.cells {
+            cell.reset();
+            cell.bg = bg;
+        }
         self.zones.clear();
     }
 
-    /// Clear a specific row
-    pub fn clear_row(&mut self, row: usize) {
+    /// Clear the entire grid with default background
+    pub fn clear(&mut self) {
+        self.clear_with_bg(DEFAULT_BG);
+    }
+
+    /// Clear a specific row, filling cells with the given background color (BCE)
+    pub fn clear_row_with_bg(&mut self, row: usize, bg: Color) {
         if let Some(row_cells) = self.row_mut(row) {
-            row_cells.fill(Cell::default());
+            for cell in row_cells.iter_mut() {
+                cell.reset();
+                cell.bg = bg;
+            }
         }
     }
 
-    /// Clear from cursor to end of line
-    pub fn clear_line_right(&mut self, col: usize, row: usize) {
+    /// Clear a specific row with default background
+    pub fn clear_row(&mut self, row: usize) {
+        self.clear_row_with_bg(row, DEFAULT_BG);
+    }
+
+    /// Clear from cursor to end of line, filling cells with the given background color (BCE)
+    pub fn clear_line_right(&mut self, col: usize, row: usize, bg: Color) {
         if row < self.rows {
             for c in col..self.cols {
                 if let Some(cell) = self.get_mut(c, row) {
                     cell.reset();
+                    cell.bg = bg;
                 }
             }
         }
     }
 
-    /// Clear from beginning of line to cursor
-    pub fn clear_line_left(&mut self, col: usize, row: usize) {
+    /// Clear from beginning of line to cursor, filling cells with the given background color (BCE)
+    pub fn clear_line_left(&mut self, col: usize, row: usize, bg: Color) {
         if row < self.rows {
             for c in 0..=col.min(self.cols - 1) {
                 if let Some(cell) = self.get_mut(c, row) {
                     cell.reset();
+                    cell.bg = bg;
                 }
             }
         }
     }
 
-    /// Clear from cursor to end of screen
-    pub fn clear_screen_below(&mut self, col: usize, row: usize) {
-        self.clear_line_right(col, row);
+    /// Clear from cursor to end of screen, filling cells with the given background color (BCE)
+    pub fn clear_screen_below(&mut self, col: usize, row: usize, bg: Color) {
+        self.clear_line_right(col, row, bg);
         for r in (row + 1)..self.rows {
-            self.clear_row(r);
+            self.clear_row_with_bg(r, bg);
         }
     }
 
-    /// Clear from beginning of screen to cursor
-    pub fn clear_screen_above(&mut self, col: usize, row: usize) {
+    /// Clear from beginning of screen to cursor, filling cells with the given background color (BCE)
+    pub fn clear_screen_above(&mut self, col: usize, row: usize, bg: Color) {
         for r in 0..row {
-            self.clear_row(r);
+            self.clear_row_with_bg(r, bg);
         }
-        self.clear_line_left(col, row);
+        self.clear_line_left(col, row, bg);
     }
 
-    /// Erase characters at (col, row)
-    pub fn erase_characters(&mut self, col: usize, row: usize, n: usize) {
+    /// Erase characters at (col, row), filling cells with the given background color (BCE)
+    pub fn erase_characters(&mut self, col: usize, row: usize, n: usize, bg: Color) {
         if row < self.rows {
             let end = (col + n).min(self.cols);
             for c in col..end {
                 if let Some(cell) = self.get_mut(c, row) {
                     cell.reset();
+                    cell.bg = bg;
                 }
             }
         }
     }
 
     /// Alias for erase_characters
-    pub fn erase_chars(&mut self, col: usize, row: usize, n: usize) {
-        self.erase_characters(col, row, n);
+    pub fn erase_chars(&mut self, col: usize, row: usize, n: usize, bg: Color) {
+        self.erase_characters(col, row, n, bg);
     }
 
     /// Clear the scrollback buffer

--- a/src/grid/tests.rs
+++ b/src/grid/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::cell::Cell;
+use crate::color::{Color, NamedColor};
 
 #[test]
 fn test_grid_creation() {
@@ -168,7 +169,7 @@ fn test_erase_chars_boundary() {
         grid.set(i, 0, Cell::new((b'X' + i as u8) as char));
     }
 
-    grid.erase_chars(5, 0, 20); // Erase 20 chars from position 5 (only 5 exist)
+    grid.erase_chars(5, 0, 20, Color::Named(NamedColor::Black)); // Erase 20 chars from position 5 (only 5 exist)
 
     assert_eq!(grid.get(4, 0).unwrap().c, '\\'); // Should be preserved (X + 4)
     for i in 5..10 {
@@ -184,7 +185,7 @@ fn test_clear_line_operations() {
     }
 
     // Clear from position 5 to end
-    grid.clear_line_right(5, 2);
+    grid.clear_line_right(5, 2, Color::Named(NamedColor::Black));
 
     assert_eq!(grid.get(4, 2).unwrap().c, 'X'); // Preserved
     assert_eq!(grid.get(5, 2).unwrap().c, ' '); // Cleared
@@ -199,7 +200,7 @@ fn test_clear_line_left() {
     }
 
     // Clear from start to position 5 (inclusive)
-    grid.clear_line_left(5, 2);
+    grid.clear_line_left(5, 2, Color::Named(NamedColor::Black));
 
     for i in 0..=5 {
         assert_eq!(grid.get(i, 2).unwrap().c, ' '); // Cleared
@@ -217,12 +218,133 @@ fn test_clear_screen_operations() {
     }
 
     // Clear from (5,5) to end of screen
-    grid.clear_screen_below(5, 5);
+    grid.clear_screen_below(5, 5, Color::Named(NamedColor::Black));
 
     assert_eq!(grid.get(4, 5).unwrap().c, 'X'); // Before cursor on same line - preserved
     assert_eq!(grid.get(5, 5).unwrap().c, ' '); // At cursor - cleared
     assert_eq!(grid.get(0, 6).unwrap().c, ' '); // Next line - cleared
     assert_eq!(grid.get(0, 4).unwrap().c, 'X'); // Previous line - preserved
+}
+
+// ===== BCE (Background Color Erase) Tests =====
+
+#[test]
+fn test_bce_clear_line_right() {
+    let mut grid = Grid::new(10, 5, 1000);
+    for i in 0..10 {
+        grid.set(i, 2, Cell::new('X'));
+    }
+    let bg = Color::Rgb(0, 128, 0); // green
+    grid.clear_line_right(5, 2, bg);
+
+    assert_eq!(grid.get(4, 2).unwrap().c, 'X'); // Preserved
+    assert_eq!(grid.get(5, 2).unwrap().c, ' '); // Cleared
+    assert_eq!(grid.get(5, 2).unwrap().bg, bg); // BCE: green bg
+    assert_eq!(grid.get(9, 2).unwrap().bg, bg); // BCE: green bg
+}
+
+#[test]
+fn test_bce_clear_line_left() {
+    let mut grid = Grid::new(10, 5, 1000);
+    for i in 0..10 {
+        grid.set(i, 2, Cell::new('X'));
+    }
+    let bg = Color::Rgb(0, 0, 255); // blue
+    grid.clear_line_left(5, 2, bg);
+
+    for i in 0..=5 {
+        assert_eq!(grid.get(i, 2).unwrap().c, ' '); // Cleared
+        assert_eq!(grid.get(i, 2).unwrap().bg, bg); // BCE: blue bg
+    }
+    assert_eq!(grid.get(6, 2).unwrap().c, 'X'); // Preserved
+}
+
+#[test]
+fn test_bce_clear_row() {
+    let mut grid = Grid::new(10, 5, 1000);
+    for i in 0..10 {
+        grid.set(i, 2, Cell::new('X'));
+    }
+    let bg = Color::Rgb(255, 0, 0); // red
+    grid.clear_row_with_bg(2, bg);
+
+    for i in 0..10 {
+        assert_eq!(grid.get(i, 2).unwrap().c, ' ');
+        assert_eq!(grid.get(i, 2).unwrap().bg, bg); // BCE: red bg
+    }
+}
+
+#[test]
+fn test_bce_clear_screen_below() {
+    let mut grid = Grid::new(10, 10, 1000);
+    for row in 0..10 {
+        for col in 0..10 {
+            grid.set(col, row, Cell::new('X'));
+        }
+    }
+    let bg = Color::Rgb(128, 0, 128); // magenta
+    grid.clear_screen_below(5, 5, bg);
+
+    assert_eq!(grid.get(4, 5).unwrap().c, 'X'); // Before cursor - preserved
+    assert_eq!(grid.get(5, 5).unwrap().c, ' '); // At cursor - cleared
+    assert_eq!(grid.get(5, 5).unwrap().bg, bg); // BCE
+    assert_eq!(grid.get(0, 6).unwrap().c, ' '); // Next line - cleared
+    assert_eq!(grid.get(0, 6).unwrap().bg, bg); // BCE
+    assert_eq!(grid.get(0, 4).unwrap().c, 'X'); // Previous line - preserved
+}
+
+#[test]
+fn test_bce_clear_screen_above() {
+    let mut grid = Grid::new(10, 10, 1000);
+    for row in 0..10 {
+        for col in 0..10 {
+            grid.set(col, row, Cell::new('X'));
+        }
+    }
+    let bg = Color::Indexed(42); // indexed color
+    grid.clear_screen_above(5, 5, bg);
+
+    assert_eq!(grid.get(0, 4).unwrap().c, ' '); // Previous line - cleared
+    assert_eq!(grid.get(0, 4).unwrap().bg, bg); // BCE
+    assert_eq!(grid.get(5, 5).unwrap().c, ' '); // At cursor - cleared
+    assert_eq!(grid.get(5, 5).unwrap().bg, bg); // BCE
+    assert_eq!(grid.get(6, 5).unwrap().c, 'X'); // After cursor - preserved
+}
+
+#[test]
+fn test_bce_erase_characters() {
+    let mut grid = Grid::new(10, 5, 1000);
+    for i in 0..10 {
+        grid.set(i, 0, Cell::new('X'));
+    }
+    let bg = Color::Rgb(0, 128, 0);
+    grid.erase_characters(3, 0, 4, bg);
+
+    assert_eq!(grid.get(2, 0).unwrap().c, 'X'); // Preserved
+    for i in 3..7 {
+        assert_eq!(grid.get(i, 0).unwrap().c, ' '); // Erased
+        assert_eq!(grid.get(i, 0).unwrap().bg, bg); // BCE
+    }
+    assert_eq!(grid.get(7, 0).unwrap().c, 'X'); // Preserved
+}
+
+#[test]
+fn test_bce_clear_with_bg() {
+    let mut grid = Grid::new(10, 3, 1000);
+    for row in 0..3 {
+        for col in 0..10 {
+            grid.set(col, row, Cell::new('X'));
+        }
+    }
+    let bg = Color::Rgb(255, 255, 0); // yellow
+    grid.clear_with_bg(bg);
+
+    for row in 0..3 {
+        for col in 0..10 {
+            assert_eq!(grid.get(col, row).unwrap().c, ' ');
+            assert_eq!(grid.get(col, row).unwrap().bg, bg); // BCE
+        }
+    }
 }
 
 #[test]
@@ -235,7 +357,7 @@ fn test_clear_screen_above() {
     }
 
     // Clear from start of screen to (5,5)
-    grid.clear_screen_above(5, 5);
+    grid.clear_screen_above(5, 5, Color::Named(NamedColor::Black));
 
     assert_eq!(grid.get(0, 4).unwrap().c, ' '); // Previous line - cleared
     assert_eq!(grid.get(5, 5).unwrap().c, ' '); // At cursor - cleared

--- a/src/terminal/sequences/csi/erase.rs
+++ b/src/terminal/sequences/csi/erase.rs
@@ -13,7 +13,8 @@ impl Terminal {
     ) {
         match action {
             'J' => {
-                // Erase in display (ED)
+                // Erase in display (ED) — BCE: fill with current SGR background
+                let bg = self.bg;
                 let n = params
                     .iter()
                     .next()
@@ -25,12 +26,12 @@ impl Terminal {
                 match n {
                     0 => self
                         .active_grid_mut()
-                        .clear_screen_below(cursor_col, cursor_row),
+                        .clear_screen_below(cursor_col, cursor_row, bg),
                     1 => self
                         .active_grid_mut()
-                        .clear_screen_above(cursor_col, cursor_row),
+                        .clear_screen_above(cursor_col, cursor_row, bg),
                     2 => {
-                        self.active_grid_mut().clear();
+                        self.active_grid_mut().clear_with_bg(bg);
                         self.graphics_store.clear();
                         self.graphics_store.clear_scrollback_graphics();
                         self.terminal_events
@@ -44,7 +45,7 @@ impl Terminal {
                         );
                     }
                     3 => {
-                        self.active_grid_mut().clear();
+                        self.active_grid_mut().clear_with_bg(bg);
                         self.active_grid_mut().clear_scrollback();
                         self.graphics_store.clear();
                         self.graphics_store.clear_scrollback_graphics();
@@ -62,7 +63,8 @@ impl Terminal {
                 }
             }
             'K' => {
-                // Erase in line (EL)
+                // Erase in line (EL) — BCE: fill with current SGR background
+                let bg = self.bg;
                 let n = params
                     .iter()
                     .next()
@@ -74,16 +76,17 @@ impl Terminal {
                 match n {
                     0 => self
                         .active_grid_mut()
-                        .clear_line_right(cursor_col, cursor_row),
+                        .clear_line_right(cursor_col, cursor_row, bg),
                     1 => self
                         .active_grid_mut()
-                        .clear_line_left(cursor_col, cursor_row),
-                    2 => self.active_grid_mut().clear_row(cursor_row),
+                        .clear_line_left(cursor_col, cursor_row, bg),
+                    2 => self.active_grid_mut().clear_row_with_bg(cursor_row, bg),
                     _ => {}
                 }
             }
             'X' => {
-                // Erase characters (ECH)
+                // Erase characters (ECH) — BCE: fill with current SGR background
+                let bg = self.bg;
                 let n = params
                     .iter()
                     .next()
@@ -94,7 +97,7 @@ impl Terminal {
                 let cursor_col = self.cursor.col;
                 let cursor_row = self.cursor.row;
                 self.active_grid_mut()
-                    .erase_characters(cursor_col, cursor_row, n);
+                    .erase_characters(cursor_col, cursor_row, n, bg);
             }
             _ => {}
         }
@@ -176,10 +179,12 @@ impl Terminal {
                 }
             }
         }
-        // Second pass: erase the collected cells
+        // Second pass: erase the collected cells with BCE
+        let bg = self.bg;
         for (col, row) in to_erase {
             if let Some(cells) = self.active_grid_mut().row_mut(row) {
-                cells[col] = crate::cell::Cell::default();
+                cells[col].reset();
+                cells[col].bg = bg;
             }
         }
 

--- a/tests/test_terminal.py
+++ b/tests/test_terminal.py
@@ -2270,5 +2270,91 @@ def test_progress_bar_does_not_affect_notifications():
     assert len(term.take_notifications()) == 0
 
 
+# ===== BCE (Background Color Erase) Tests =====
+
+
+def test_bce_el0_clear_to_end_of_line():
+    """EL 0 (\\x1b[K) should fill erased cells with current SGR background"""
+    term = Terminal(40, 2)
+    # Set green background, write text, then erase to end of line
+    term.process_str("\x1b[42mGREEN+EL\x1b[K")
+
+    # Text cells should have green bg
+    bg_text = term.get_bg_color(0, 0)
+    assert bg_text == (0, 128, 0), f"Text cell bg should be green, got {bg_text}"
+
+    # Erased cells (beyond text) should also have green bg (BCE)
+    bg_erased = term.get_bg_color(20, 0)
+    assert bg_erased == (0, 128, 0), f"Erased cell bg should be green, got {bg_erased}"
+
+
+def test_bce_el1_clear_to_start_of_line():
+    """EL 1 (\\x1b[1K) should fill erased cells with current SGR background"""
+    term = Terminal(40, 2)
+    # Write text, move to col 9, set red bg, erase to start
+    term.process_str("ABCDEFGHIJ\x1b[41m\x1b[9G\x1b[1K")
+
+    # Erased cells (0-8) should have red bg
+    bg_erased = term.get_bg_color(0, 0)
+    assert bg_erased == (128, 0, 0), f"Erased cell bg should be red, got {bg_erased}"
+
+
+def test_bce_el2_clear_entire_line():
+    """EL 2 (\\x1b[2K) should fill entire line with current SGR background"""
+    term = Terminal(40, 2)
+    term.process_str("\x1b[44mBLUE\x1b[2K")
+
+    # All cells on the line should have blue bg
+    bg = term.get_bg_color(0, 0)
+    assert bg == (0, 0, 128), f"Line start bg should be blue, got {bg}"
+    bg_end = term.get_bg_color(39, 0)
+    assert bg_end == (0, 0, 128), f"Line end bg should be blue, got {bg_end}"
+
+
+def test_bce_ed0_clear_to_end_of_screen():
+    """ED 0 (\\x1b[J) should fill erased cells with current SGR background"""
+    term = Terminal(20, 5)
+    term.process_str("\x1b[45m\x1b[H\x1b[J")
+
+    # All cells should have magenta bg
+    bg = term.get_bg_color(0, 0)
+    assert bg == (128, 0, 128), f"Cell (0,0) bg should be magenta, got {bg}"
+    bg_last = term.get_bg_color(19, 4)
+    assert bg_last == (128, 0, 128), f"Last cell bg should be magenta, got {bg_last}"
+
+
+def test_bce_ed2_clear_entire_screen():
+    """ED 2 (\\x1b[2J) should fill entire screen with current SGR background"""
+    term = Terminal(20, 5)
+    term.process_str("SOME TEXT")
+    term.process_str("\x1b[46m\x1b[2J")
+
+    # All cells should be cleared with cyan bg
+    bg = term.get_bg_color(0, 0)
+    assert bg == (0, 128, 128), f"Cell (0,0) bg should be cyan, got {bg}"
+    bg_last = term.get_bg_color(19, 4)
+    assert bg_last == (0, 128, 128), f"Last cell bg should be cyan, got {bg_last}"
+
+
+def test_bce_ech_erase_characters():
+    """ECH (\\x1b[X) should fill erased cells with current SGR background"""
+    term = Terminal(40, 2)
+    term.process_str("AAAAAAAAAAAAAAAA")
+    term.process_str("\x1b[42m\x1b[1;1H\x1b[5X")
+
+    # First 5 cells erased with green bg
+    bg = term.get_bg_color(0, 0)
+    assert bg == (0, 128, 0), f"Erased cell bg should be green, got {bg}"
+
+
+def test_bce_default_bg_is_black():
+    """Without SGR bg set, erase should use default black bg"""
+    term = Terminal(40, 2)
+    term.process_str("Hello\x1b[K")
+
+    bg_erased = term.get_bg_color(10, 0)
+    assert bg_erased == (0, 0, 0), f"Default bg should be black, got {bg_erased}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #57 — all VT erase operations now fill erased cells with the current SGR background color instead of always resetting to black.

## Problem

`\x1b[K` (EL), `\x1b[J` (ED), `\x1b[X` (ECH), and DECSERA erased cells always got `Cell::default()` background (black), ignoring the terminal's active SGR background color. This violated standard VT behavior and caused visible rendering differences compared to iTerm2/Alacritty/Windows Terminal.

## Solution

- Grid erase methods (`clear_line_right`, `clear_line_left`, `clear_row_with_bg`, `clear_screen_below`, `clear_screen_above`, `erase_characters`, `clear_with_bg`) now accept a `bg: Color` parameter
- CSI erase handler passes `self.bg` (current SGR background) to all erase operations
- DECSERA selective erase also uses BCE
- Scroll/edit operations continue using default black bg (BCE does not apply to scroll)
- Kept backward-compatible no-bg methods (`clear()`, `clear_row()`) for non-erase callers

## Testing

- **7 new Rust unit tests** for BCE behavior on each erase method
- **7 new Python integration tests** covering EL (0/1/2), ED (0/2), ECH, and default-black fallback
- All 1696 Rust tests pass, all 149 Python tests pass
- `make checkall` passes cleanly

## Files Changed

| File | Change |
|------|--------|
| `src/grid/erase.rs` | Added `bg: Color` param to erase methods, `reset()` + set bg |
| `src/terminal/sequences/csi/erase.rs` | Pass `self.bg` to all erase calls, DECSERA BCE |
| `src/grid/tests.rs` | Updated existing tests + 7 new BCE tests |
| `tests/test_terminal.py` | 7 new Python BCE integration tests |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Background Color Erase (BCE) support for terminal erase operations, allowing erased regions to be filled with the current SGR background color instead of default.
  * Erase in line (EL), erase in display (ED), and erase characters (ECH) commands now respect active background colors.

* **Tests**
  * Added comprehensive test coverage for BCE behavior with various erase commands and background color scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->