### PR TITLE
fix(pty): move generation counter increment before processing

### DIFF
--- a/src/pty_session.rs
+++ b/src/pty_session.rs
@@ -627,6 +627,14 @@ impl PtySession {
                     Ok(n) => {
                         debug::log_pty_read(n);
 
+                        // Bump generation counter IMMEDIATELY on successful read,
+                        // before any processing. This guarantees the counter always
+                        // advances when PTY data arrives, even if processing encounters
+                        // a panic or unexpected code path (e.g., Windows ConPTY after
+                        // Ctrl+C where subsequent sequences may cause issues).
+                        let old_gen = update_generation.fetch_add(1, Ordering::SeqCst);
+                        debug::log_generation_change(old_gen, old_gen + 1, "PTY read");
+
                         // Call output callback if set (for streaming, logging, etc.)
                         {
                             let callback_guard = output_callback.lock();
@@ -644,7 +652,6 @@ impl PtySession {
                         // Process the bytes through the terminal
                         {
                             let mut term = terminal.lock();
-                            let old_gen = update_generation.load(Ordering::SeqCst);
                             let was_alt_screen = term.is_alt_screen_active();
                             term.process(&buffer[..n]);
                             // Record output for session recording
@@ -746,10 +753,6 @@ impl PtySession {
                                     }
                                 }
                             }
-
-                            // Increment update generation to signal content changed
-                            let new_gen = update_generation.fetch_add(1, Ordering::SeqCst) + 1;
-                            debug::log_generation_change(old_gen, new_gen, "PTY read");
                         }
                     }
                     Err(e) => {
@@ -1726,6 +1729,101 @@ mod tests {
             );
         }
         // If gen == 0, the session just started with no updates; skip the check.
+    }
+
+    /// Regression test for issue #60: generation counter must increment
+    /// on every successful PTY read, even if terminal processing encounters
+    /// unexpected sequences (e.g., Windows ConPTY after Ctrl+C).
+    ///
+    /// This test spawns a real PTY, writes data, and verifies that
+    /// `has_updates_since()` correctly detects the change.
+    #[test]
+    fn test_generation_counter_increments_on_pty_output() {
+        let mut session = PtySession::new(80, 24, 1000);
+
+        // Spawn a simple command that exits immediately
+        #[cfg(unix)]
+        let result = session.spawn("/bin/echo", &["hello"]);
+        #[cfg(windows)]
+        let result = session.spawn("cmd.exe", &["/C", "echo hello"]);
+
+        assert!(result.is_ok());
+
+        let gen_before = session.update_generation();
+
+        // Wait for the command to execute and produce output
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        // The generation counter MUST have incremented because the reader
+        // thread read data from the PTY (echo produces "hello\r\n").
+        let gen_after = session.update_generation();
+        assert!(
+            gen_after > gen_before,
+            "generation counter should have incremented after PTY output: was {}, now {}",
+            gen_before,
+            gen_after
+        );
+        assert!(
+            session.has_updates_since(gen_before),
+            "has_updates_since() should return true after PTY output"
+        );
+    }
+
+    /// Test that generation counter increments are not blocked by terminal
+    /// processing issues. Simulates the Ctrl+C scenario from issue #60 by
+    /// spawning a shell, sending Ctrl+C, then sending normal data and
+    /// verifying the generation counter still advances.
+    #[test]
+    fn test_generation_counter_after_ctrl_c() {
+        let mut session = PtySession::new(80, 24, 1000);
+
+        // Spawn a shell
+        #[cfg(unix)]
+        let result = session.spawn_shell();
+        #[cfg(windows)]
+        let result = session.spawn_shell();
+
+        assert!(result.is_ok());
+
+        // Wait for shell to start
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        let gen_before_ctrl_c = session.update_generation();
+
+        // Send Ctrl+C
+        session.write(b"\x03").unwrap();
+
+        // Wait for Ctrl+C to be processed
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        // Generation should have incremented due to shell prompt redraw after Ctrl+C
+        let gen_after_ctrl_c = session.update_generation();
+        assert!(
+            gen_after_ctrl_c >= gen_before_ctrl_c,
+            "generation counter should have incremented after Ctrl+C: was {}, now {}",
+            gen_before_ctrl_c,
+            gen_after_ctrl_c
+        );
+
+        // Now send a normal command
+        let gen_before_echo = session.update_generation();
+        session.write(b"echo TEST_GENERATION\r\n").unwrap();
+
+        // Wait for output
+        std::thread::sleep(std::time::Duration::from_millis(500));
+
+        // Generation MUST increment for the echo output
+        let gen_after_echo = session.update_generation();
+        assert!(
+            gen_after_echo > gen_before_echo,
+            "generation counter should increment for output after Ctrl+C: was {}, now {}",
+            gen_before_echo,
+            gen_after_echo
+        );
+        assert!(
+            session.has_updates_since(gen_before_echo),
+            "has_updates_since() must detect changes after Ctrl+C"
+        );
     }
 
     #[test]

--- a/tests/test_pty.py
+++ b/tests/test_pty.py
@@ -283,6 +283,70 @@ def test_pty_terminal_title():
     # 3. It matches the Terminal API contract
 
 
+def test_update_generation_initial():
+    """Test that generation counter starts at 0"""
+    from par_term_emu_core_rust import PtyTerminal
+
+    term = PtyTerminal(80, 24)
+    assert term.update_generation() == 0
+
+
+def test_has_updates_since_no_changes():
+    """Test that has_updates_since returns False when no changes occurred"""
+    from par_term_emu_core_rust import PtyTerminal
+
+    term = PtyTerminal(80, 24)
+    gen = term.update_generation()
+    assert not term.has_updates_since(gen)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix-specific test")
+def test_generation_counter_increments_on_output():
+    """Regression test for issue #60: generation counter must increment on PTY output."""
+    from par_term_emu_core_rust import PtyTerminal
+
+    term = PtyTerminal(80, 24)
+    term.spawn("/bin/echo", args=["hello"])
+
+    gen_before = term.update_generation()
+    time.sleep(0.3)
+
+    gen_after = term.update_generation()
+    assert gen_after > gen_before, (
+        f"generation counter should increment after PTY output: was {gen_before}, now {gen_after}"
+    )
+    assert term.has_updates_since(gen_before), (
+        "has_updates_since() should return True after PTY output"
+    )
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix-specific test")
+def test_generation_counter_after_ctrl_c():
+    """Regression test for issue #60: generation counter must still work after Ctrl+C."""
+    from par_term_emu_core_rust import PtyTerminal
+
+    term = PtyTerminal(80, 24)
+    term.spawn_shell()
+    time.sleep(0.5)
+
+    # Send Ctrl+C
+    term.write(b"\x03")
+    time.sleep(0.3)
+
+    # Send a normal command after Ctrl+C
+    gen_before = term.update_generation()
+    term.write_str("echo GENERATION_TEST\n")
+    time.sleep(0.5)
+
+    gen_after = term.update_generation()
+    assert gen_after > gen_before, (
+        f"generation counter should increment for output after Ctrl+C: was {gen_before}, now {gen_after}"
+    )
+    assert term.has_updates_since(gen_before), (
+        "has_updates_since() must detect changes after Ctrl+C"
+    )
+
+
 def test_pty_terminal_hyperlink():
     """Test getting hyperlink from PtyTerminal"""
     from par_term_emu_core_rust import PtyTerminal, Terminal


### PR DESCRIPTION
## Summary

Fixes #60 — `has_updates_since()` unreliable on Windows after Ctrl+C.

## Root Cause

The generation counter (`fetch_add`) was at the **end** of a long processing block in the PTY reader thread (after terminal processing, response handling, and alt-screen logic). If any of that code panicked or took an unexpected code path — notably on Windows ConPTY after `Ctrl+C` — the counter would never increment, even though `term.process()` had already written data to the grid buffer.

## Fix

Move the `fetch_add(1)` to **immediately after a successful `reader.read()`**, before any processing. This guarantees the counter always advances when PTY data arrives.

**Before:**
```rust
Ok(n) => {
    // ... callbacks ...
    {
        let mut term = terminal.lock();
        term.process(&buffer[..n]);
        // ... 100 lines of response/alt-screen handling ...
        let new_gen = update_generation.fetch_add(1, ...); // ← at the end
    }
}
```

**After:**
```rust
Ok(n) => {
    // Bump immediately on successful read
    let old_gen = update_generation.fetch_add(1, ...); // ← right here
    // ... callbacks and processing (counter already bumped) ...
}
```

## Testing

- **Rust:** Added `test_generation_counter_increments_on_pty_output` and `test_generation_counter_after_ctrl_c` — both pass
- **Python:** Added 4 tests in `test_pty.py` covering generation counter initial state, no-change case, output detection, and post-Ctrl+C behavior
- All `make checkall` checks pass (Rust tests, clippy, fmt, Python tests, ruff, pyright)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PTY session generation counter now advances immediately after each successful read from the terminal master, ensuring updates are properly tracked.

* **Tests**
  * Added regression tests to verify PTY session generation counter behavior and update tracking, including scenarios with command execution and Ctrl+C sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->